### PR TITLE
Curtis dev

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ nanoporeWorkflow's intended scope is to be a modular workflow that can carry out
 ## Other contribution notes
 
 * Pull requests which improve performance (but do not change nanoporeWorkflow's behaviour) are also welcome!
-* Badread is not using feature branches. I will therefore merge pull requests into the master branch and make a new [release](https://github.com/lskatz/nanoporeWorkflow/releases) when I'm confident that everything works as intended.
+* nanoporeWorkflow is not using feature branches. I will therefore merge pull requests into the master branch and make a new [release](https://github.com/lskatz/nanoporeWorkflow/releases) when I'm confident that everything works as intended.
 * Don't worry about changing nanoporeWorkflow's version number in your pull request. We will bump the version when I make a new release.
 * Adding new dependencies that are not available on SciComp to nanoporeWorkflow is discouraged. Please refrain from doing so unless it is justified.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,74 @@
+# Contributing to nanoporeWorkflow
+
+Thanks for your interest in contributing to nanoporeWorkflow! Please have a quick read of this page before making a change, so you know what to expect.
+
+
+
+## Bug fixes
+
+If you have discovered a bug, please report it via the GitHub [issue tracker](https://github.com/lskatz/nanoporeWorkflow/issues).
+
+Bug-fix [pull requests](https://github.com/lskatz/nanoporeWorkflow/pulls) are always welcome! 
+
+
+
+## New features
+
+nanoporeWorkflow's intended scope is to be a modular workflow that can carry out different tasks on Nanopore data. We would be interested in merging it in via a [pull request](https://github.com/lskatz/nanoporeWorkflow/pulls)! Along with your new feature, please make any necessary updates to the [README.md](https://github.com/https://github.com/lskatz/nanoporeWorkflow/blob/master/README.md) file to describe the feature and its usage.
+
+
+
+## Other contribution notes
+
+* Pull requests which improve performance (but do not change nanoporeWorkflow's behaviour) are also welcome!
+* Badread is not using feature branches. I will therefore merge pull requests into the master branch and make a new [release](https://github.com/lskatz/nanoporeWorkflow/releases) when I'm confident that everything works as intended.
+* Don't worry about changing nanoporeWorkflow's version number in your pull request. We will bump the version when I make a new release.
+* Adding new dependencies that are not available on SciComp to nanoporeWorkflow is discouraged. Please refrain from doing so unless it is justified.
+
+
+
+## Code of conduct
+
+### Our pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+### Our standards
+
+Examples of behaviour that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behaviour by participants include:
+
+* The use of sexualised language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+### Our responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behaviour and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behaviour.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviours that they deem inappropriate, threatening, offensive, or harmful.
+
+### Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+### Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be reported by contacting the project team at pjx8@cdc.gov and gzu2@cdc.gov . All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+### Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant version 1.4, available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+For answers to common questions about this code of conduct, see https://www.contributor-covenant.org/faq

--- a/README.md
+++ b/README.md
@@ -8,3 +8,64 @@ This is a collection of scripts that do one thing at a time.  For example, demul
 
 This is a collection of workflows in the form of shell scripts.  They qsub the scripts individually.
 The first positional parameter must be the project folder.  Both input and output go to the project folder.
+
+### Workflow 1: `run_01_basecall-w-gpu.sh` - `guppy` GPU basecalling and demultiplexing with `qcat`
+`run_01_basecall-w-gpu.sh` is the runner/driver script for `01_basecall-w-gpu.sh`
+
+#### Requirements
+  * Must be run while logged into directly node98 (Tesla V100 GPUs will eventually be a part of `qsub`, but are not currently, do NOT use qsub or run script on another node _unless it has a V100 GPU installed_)
+  * No one else must be running stuff on the node - this Guppy command will eat up all GPU resources
+    * check CPU usage with `htop` and GPU usage with `nvtop` before running the script
+  * Must be MinION data, generated with an R9.4.1 flowcell (FLO-MIN106) and ligation sequencing kit (SQK-LSK109)
+    * Must be Native Barcodes 1-24 (NBD103/104/114)
+
+#### This workflow does the following:
+  * Takes in 3 arguments (in this order):
+    1. `$OUTDIR` - an output directory
+    2. `$FAST5DIR` - a directory containing raw fast5 files
+    3. `$MODE` - basecalling mode/configuration - either `fast` or `hac` (high accuracy)
+  * copies fast5s from `$FAST5DIR` to `/tmp/$USER/guppy.gpu.XXXXXX`
+  * runs `guppy_basecaller` in either `fast` or `hac` mode
+    * According to ONT - High accuracy mode will take anywhere from 5-8X longer to complete basecalling than fast mode, but will result in 2-3% higher read accuracy. 
+  * Demultiplexes using `qcat` and additionally trims adapter and barcode sequences (using `--trim` option w/ `qcat`)
+  * Copies demultiplexed & trimmed reads into subdirectories in `$OUTDIR/demux/barcodeXX`
+  * Logs STDOUT from last time script was ran in `$OUTDIR/log/logfile-gpu-basecalling.txt` and all previous times in `$OUTDIR/log/logfile-gpu-basecalling_prev.txt`
+ 
+ #### USAGE:
+```bash
+cd ~/
+# download the scripts
+# TODO - CHANGE THIS TO DL A SPECIFIC RELEASE
+git clone https://github.com/lskatz/nanoporeWorkflow.git
+
+# Specified dirs MUST end with a '/'
+Usage: 
+# fast mode
+    ~/nanoporeWorkflow/workflows/run_01_basecall-w-gpu.sh outdir/ fast5dir/ fast
+# high accuracy mode
+    ~/nanoporeWorkflow/workflows/run_01_basecall-w-gpu.sh outdir/ fast5dir/ hac
+
+# OUTPUT
+$OUTDIR
+├── demux
+│   ├── barcode06
+│   │   └── barcode06.fastq
+│   ├── barcode10
+│   │   └── barcode10.fastq
+│   ├── barcode12
+│   │   └── barcode12.fastq
+│   ├── none.fastq
+│   └── sequencing_summary.txt
+└── log
+    ├── logfile-gpu-basecalling_prev.txt # only present if you ran the script more than once
+    └── logfile-gpu-basecalling.txt
+```
+ 
+#### Future plans/To-do:
+  * Compress demuxed reads using `pigz`. Latest release of Guppy v 3.1.5 (not available/installed on node98) includes an option for producing gzipped reads, but is not yet installed on node 98.
+  * add flags/options for other sequencing kits, barcoding kits, flowcells (direct RNAseq?)
+  
+### Resources
+  * https://github.com/nanoporetech/qcat
+  * How to set Guppy parameters (requires Nanopore Community login credentials) https://community.nanoporetech.com/protocols/Guppy-protocol/v/gpb_2003_v1_revl_14dec2018/how-to-configure-guppy-parameters
+  * 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The first positional parameter must be the project folder.  Both input and outpu
   * runs `guppy_basecaller` in either `fast` or `hac` mode
     * According to ONT - High accuracy mode will take anywhere from 5-8X longer to complete basecalling than fast mode, but will result in 2-3% higher read accuracy. 
   * Demultiplexes using `qcat` and additionally trims adapter and barcode sequences (using `--trim` option w/ `qcat`)
+  * Compresses (gzip) the demultiplexed reads
   * Copies demultiplexed & trimmed reads into subdirectories in `$OUTDIR/demux/barcodeXX`
   * Logs STDOUT from last time script was ran in `$OUTDIR/log/logfile-gpu-basecalling.txt` and all previous times in `$OUTDIR/log/logfile-gpu-basecalling_prev.txt`
  
@@ -49,12 +50,12 @@ Usage:
 $OUTDIR
 ├── demux
 │   ├── barcode06
-│   │   └── barcode06.fastq
+│   │   └── barcode06.fastq.gz
 │   ├── barcode10
-│   │   └── barcode10.fastq
+│   │   └── barcode10.fastq.gz
 │   ├── barcode12
-│   │   └── barcode12.fastq
-│   ├── none.fastq
+│   │   └── barcode12.fastq.gz
+│   ├── none.fastq.gz
 │   └── sequencing_summary.txt
 └── log
     ├── logfile-gpu-basecalling_prev.txt # only present if you ran the script more than once
@@ -62,8 +63,8 @@ $OUTDIR
 ```
  
 #### Future plans/To-do:
-  * Compress demuxed reads using `pigz`. Latest release of Guppy v 3.1.5 (not available/installed on node98) includes an option for producing gzipped reads, but is not yet installed on node 98.
   * add flags/options for other sequencing kits, barcoding kits, flowcells (direct RNAseq?)
+  * Create contributing.md (use this as a guide/model: https://github.com/rrwick/Badread/blob/master/CONTRIBUTING.md )
   
 ### Resources
   * https://github.com/nanoporetech/qcat

--- a/README.md
+++ b/README.md
@@ -1,15 +1,31 @@
 # nanoporeWorkflow
 
-## scripts
+Shell scripts and workflows for working with Nanopore data. Most scripts use `qsub`, the GPU basecalling script does not.
 
-This is a collection of scripts that do one thing at a time.  For example, demultiplexing or basecalling.
+Started by [@lskatz](https://github.com/lskatz), contributions from [@kapsakcj](https://github.com/kapsakcj) and potentially YOU!
 
-## workflows
+## TOC
+  * [Scripts](#scripts)
+  * [Workflows](#workflows)
+    * [Guppy GPU basecalling and demultiplexing with qcat](#guppy-gpu-basecalling-and-demultiplexing-with-qcat)
+  * [Contributing](#contributing)
+  * [Future Plans](#future-plans)
+  * [Resources](#resources)
 
-This is a collection of workflows in the form of shell scripts.  They qsub the scripts individually.
-The first positional parameter must be the project folder.  Both input and output go to the project folder.
+## Scripts
 
-### Workflow 1: `run_01_basecall-w-gpu.sh` - `guppy` GPU basecalling and demultiplexing with `qcat`
+This is a collection of scripts that do one thing at a time.  For example, demultiplexing or basecalling [except for `01_basecall-w-gpu.sh` which does both :) ].
+
+## Workflows
+
+This is a collection of workflows in the form of shell scripts.  They `qsub` the scripts individually (except for `run_basecalling-w-gpu.sh` since the GPUs aren't available through `qsub` yet).
+
+For `workflow.sh` the first positional parameter must be the project folder.  Both input and output go to the project folder.
+
+### Guppy GPU basecalling and demultiplexing with qcat
+
+`run_01_basecall-w-gpu.sh` - `guppy` GPU basecalling (& adapter trimming) and demultiplexing (& adapter/barcode trimming) with `qcat`
+
 `run_01_basecall-w-gpu.sh` is the runner/driver script for `01_basecall-w-gpu.sh`
 
 #### Requirements
@@ -18,6 +34,7 @@ The first positional parameter must be the project folder.  Both input and outpu
     * check CPU usage with `htop` and GPU usage with `nvtop` before running the script
   * Must be MinION data, generated with an R9.4.1 flowcell (FLO-MIN106) and ligation sequencing kit (SQK-LSK109)
     * Must be Native Barcodes 1-24 (NBD103/104/114)
+    * We'd like to add flags for other flowcells and sequencing kit when we come across data from those!
 
 #### This workflow does the following:
   * Takes in 3 arguments (in this order):
@@ -61,12 +78,14 @@ $OUTDIR
     ├── logfile-gpu-basecalling_prev.txt # only present if you ran the script more than once
     └── logfile-gpu-basecalling.txt
 ```
- 
-#### Future plans/To-do:
+
+## Contributing
+If you are interested in contributing to nanoporeWorkflow, please take a look at the [contribution guidelines](CONTRIBUTING.md). We welcome issues or pull requests!
+
+## Future plans
   * add flags/options for other sequencing kits, barcoding kits, flowcells (direct RNAseq?)
-  * Create contributing.md (use this as a guide/model: https://github.com/rrwick/Badread/blob/master/CONTRIBUTING.md )
   
-### Resources
+## Resources
   * https://github.com/nanoporetech/qcat
   * How to set Guppy parameters (requires Nanopore Community login credentials) https://community.nanoporetech.com/protocols/Guppy-protocol/v/gpb_2003_v1_revl_14dec2018/how-to-configure-guppy-parameters
-  * 
+

--- a/scripts/01_basecall-w-gpu.sh
+++ b/scripts/01_basecall-w-gpu.sh
@@ -21,14 +21,14 @@ NSLOTS=${NSLOTS:=36}
 
 OUTDIR=$1
 FAST5DIR=$2
-GENOMELENGTH=5000000 # TODO make this a parameter
-LONGREADCOVERAGE=50  # How much coverage to target with long reads
-
 
 if [[ "$FAST5DIR" == "" ]]; then
-    echo "Usage: $0 outdir fast5dir/"
-    echo "  The outdir will represent each sample in a 'barcode__' subdirectory"
-    exit 1;
+      echo ""
+      echo "    Usage: $0 outdir/ fast5dir/ fast"
+      echo "               OR"
+      echo "    Usage: $0 outdir/ fast5dir/ hac"
+      echo ""
+      exit 1;
 fi;
 
 # check to make sure $MODE is set to either 'fast' or 'hac'
@@ -60,12 +60,11 @@ echo '$USER is set to:' $USER
 # Setup tempdir in /tmp
 # Cory recommended this since it will be faster than NFS GWA storage, lower latency as well
 tmpdir=$(mktemp -p /tmp/$USER/ -d guppy.gpu.XXXXXX)
-# rm -rf $tmpdir removed so that it doesn't delete files - TODO add back later
 trap ' { echo "END - $(date)"; rm -rf $tmpdir; } ' EXIT
 make_directory $tmpdir/log
 echo "$0: temp dir is $tmpdir";
 
-#copy fast5s to $tmpdir
+# copy fast5s to $tmpdir
 make_directory $tmpdir/fast5
 fast5tmp=$tmpdir/fast5
 echo '$fast5tmp dir is set to:' $fast5tmp
@@ -82,10 +81,9 @@ fi
 # no module load for guppy, since it's installed natively on node 98
 module load qcat/1.0.1
 
-# Basecalling using GPU
+#### Basecalling using GPU ####
 # should return version 3.0.3
 guppy_basecaller -v
-# basecalling
 # check to see if basecalling has been done by checking OUTDIR/demux/ for sequencing_summary.txt
 if [[ -e $OUTDIR/demux/sequencing_summary.txt ]]; then
   echo "FAST5 files have already been basecalled. Skipping."

--- a/scripts/01_basecall-w-gpu.sh
+++ b/scripts/01_basecall-w-gpu.sh
@@ -22,7 +22,7 @@ NSLOTS=${NSLOTS:=36}
 OUTDIR=$1
 FAST5DIR=$2
 GENOMELENGTH=5000000 # TODO make this a parameter
-LONGREADCOVERAGE=50  # How much coverage to target with long reads:wq
+LONGREADCOVERAGE=50  # How much coverage to target with long reads
 
 
 if [[ "$FAST5DIR" == "" ]]; then

--- a/scripts/01_basecall-w-gpu.sh
+++ b/scripts/01_basecall-w-gpu.sh
@@ -77,6 +77,7 @@ if [[ -e  ${OUTDIR}demux/ ]]; then
     echo "Demuxed fastqs present in OUTDIR. Exiting script..."
     exit 0
 else
+    echo "Copying reads from $FAST5DIR to $tmpdir"
     cp -rv $FAST5DIR $fast5tmp
 fi
 

--- a/scripts/01_basecall-w-gpu.sh
+++ b/scripts/01_basecall-w-gpu.sh
@@ -89,9 +89,45 @@ if [[ -e $OUTDIR/demux/sequencing_summary.txt ]]; then
   echo "FAST5 files have already been basecalled. Skipping."
 else
   if [[ "$3" == "hac"  ]]; then
-  guppy_basecaller -i $fast5tmp -s $tmpdir/fastq --num_callers $NSLOTS --qscore_filtering 7 --enable_trimming yes --hp_correct yes -r -x auto -m /opt/ont/guppy/data/template_r9.4.1_450bps_hac.jsn --chunk_size 1000 --gpu_runners_per_device 7 --chunks_per_runner 1100 --chunks_per_caller 10000 --overlap 50 --qscore_offset 0.25 --qscore_scale 0.91 --builtin_scripts 1 --disable_pings
+  guppy_basecaller -i $fast5tmp \
+                   -s $tmpdir/fastq \
+                   --num_callers $NSLOTS \
+                   --qscore_filtering 7 \
+                   --enable_trimming yes \
+                   --hp_correct yes \
+                   -r \
+                   -x "cuda:0 cuda:1" \
+                   -m /opt/ont/guppy/data/template_r9.4.1_450bps_hac.jsn \
+                   -c /opt/ont/guppy/data/dna_r9.4.1_450bps_hac.cfg \
+                   --chunk_size 1100 \
+                   --gpu_runners_per_device 7 \
+                   --chunks_per_runner 1000 \
+                   --chunks_per_caller 10000 \
+                   --overlap 50 \
+                   --qscore_offset 0.25 \
+                   --qscore_scale 0.91 \
+                   --builtin_scripts 1 \
+                   --disable_pings
   elif [[ "$3" == "fast" ]]; then
-  guppy_basecaller -i $fast5tmp -s $tmpdir/fastq --kit SQK-LSK109 --flowcell FLO-MIN106 --num_callers $NSLOTS --qscore_filtering 7 --enable_trimming yes --hp_correct yes -r -x auto -m /opt/ont/guppy/data/template_r9.4.1_450bps_fast.jsn --chunk_size 10000 --gpu_runners_per_device 7 --chunks_per_runner 256 --overlap 50 --qscore_offset -0.4 --qscore_scale 0.98 --builtin_scripts 1 --disable_pings
+  guppy_basecaller -i $fast5tmp \
+                   -s $tmpdir/fastq \
+                   --qscore_filtering 7 \
+                   --enable_trimming yes \
+                   --hp_correct yes \
+                   -r \
+                   -x "cuda:0 cuda:1" \
+                   -m /opt/ont/guppy/data/template_r9.4.1_450bps_fast.jsn \
+                   -c /opt/ont/guppy/data/dna_r9.4.1_450bps_fast.cfg \
+                   --chunk_size 1000 \
+                   --gpu_runners_per_device 8 \
+                   --chunks_per_runner 256 \
+                   --chunks_per_caller 10000 \
+                   --overlap 50 \
+                   --qscore_offset -0.4 \
+                   --qscore_scale 0.98 \
+                   --builtin_scripts 1 \
+                   --disable_pings \
+                   --num_callers $NSLOTS
   fi
 fi
 

--- a/workflows/run_01_basecall-w-gpu.sh
+++ b/workflows/run_01_basecall-w-gpu.sh
@@ -37,4 +37,6 @@ fi;
 
 make_directory ${OUTDIR}log
 
-command time -v /scicomp/home/pjx8/github/nanoporeWorkflow/scripts/01_basecall-w-gpu.sh ${OUTDIR} ${FAST5DIR} ${MODE} |& tee ${OUTDIR}log/logfile-gpu-basecalling.txt
+thisDir=$(dirname $0)
+
+command time -v ${thisDir}/../scripts/01_basecall-w-gpu.sh ${OUTDIR} ${FAST5DIR} ${MODE} |& tee ${OUTDIR}log/logfile-gpu-basecalling.txt

--- a/workflows/run_01_basecall-w-gpu.sh
+++ b/workflows/run_01_basecall-w-gpu.sh
@@ -15,7 +15,7 @@ OUTDIR=$1
 FAST5DIR=$2
 MODE=$3
 
-if find ${OUTDIR}log/logfile-gpu-basecalling.txt;
+if find ${OUTDIR}log/logfile-gpu-basecalling.txt 2>/dev/null ;
 then
     cat ${OUTDIR}log/logfile-gpu-basecalling.txt >> ${OUTDIR}log/logfile-gpu-basecalling_prev.txt
     echo "--------------------------------" >> ${OUTDIR}log/logfile-gpu-basecalling_prev.txt
@@ -24,7 +24,6 @@ fi
 
 echo '$OUTDIR is set to:' ${OUTDIR}
 echo '$FAST5DIR is set to :' ${FAST5DIR}
-echo '$MODE is set to :' ${MODE}
 
 if [ "$FAST5DIR" == "" ]; then
     echo "Specified dirs MUST end with a '/'"

--- a/workflows/run_01_basecall-w-gpu.sh
+++ b/workflows/run_01_basecall-w-gpu.sh
@@ -13,6 +13,7 @@ make_directory() {
 
 OUTDIR=$1
 FAST5DIR=$2
+MODE=$3
 
 if find ${OUTDIR}log/logfile-gpu-basecalling.txt;
 then
@@ -21,8 +22,9 @@ then
     echo "--------------------------------" >> ${OUTDIR}log/logfile-gpu-basecalling_prev.txt
 fi
 
-echo '$OUTDIR is set to:' $OUTDIR
-echo '$FAST5DIR is set to :' $FAST5DIR
+echo '$OUTDIR is set to:' ${OUTDIR}
+echo '$FAST5DIR is set to :' ${FAST5DIR}
+echo '$MODE is set to :' ${MODE}
 
 if [ "$FAST5DIR" == "" ]; then
     echo "Specified dirs MUST end with a '/'"
@@ -33,4 +35,4 @@ fi;
 
 make_directory ${OUTDIR}log
 
-command time -v /scicomp/home/pjx8/github/nanoporeWorkflow/scripts/01_basecall-w-gpu.sh $OUTDIR $FAST5DIR |& tee ${OUTDIR}log/logfile-gpu-basecalling.txt
+command time -v /scicomp/home/pjx8/github/nanoporeWorkflow/scripts/01_basecall-w-gpu.sh ${OUTDIR} ${FAST5DIR} ${MODE} |& tee ${OUTDIR}log/logfile-gpu-basecalling.txt

--- a/workflows/run_01_basecall-w-gpu.sh
+++ b/workflows/run_01_basecall-w-gpu.sh
@@ -26,9 +26,12 @@ echo '$OUTDIR is set to:' ${OUTDIR}
 echo '$FAST5DIR is set to :' ${FAST5DIR}
 
 if [ "$FAST5DIR" == "" ]; then
+    echo ""
     echo "Specified dirs MUST end with a '/'"
-    echo "Usage: $0 outdir/ fast5dir/"
-    echo "  The outdir will represent each sample in a 'barcode__' subdirectory"
+    echo "Usage: $0 outdir/ fast5dir/ fast"
+    echo "              OR"
+    echo "Usage: $0 outdir/ fast5dir/ hac"
+    echo "  The outdir will represent each sample in a 'demux/barcode__' subdirectory"
     exit 1;
 fi;
 


### PR DESCRIPTION
This PR has the following edits/contributions
  * added CONTRIBUTING.md (modeled after Ryan Wick's Badread contributing.md)
  * updated README with TOC (w/ links), edited for clarity, added section for usage of gpu-basecalling scripts
  * gpu-basecalling script changes:
    * adjusted gpu-basecalling scripts to not be specific to pjx8, any user can run them
    * USAGE echo statements fixed and edited for visibility on cmdline
    * added third positional argument to `run_01_basecall-w-gpu.sh` to require setting `fast` or `hac` for different Guppy basecalling modes/models. Added checks to make sure either `fast` or `hac` is specified with error echo statment
    * after demultiplexing w `qcat`, fastq files are now gzipped (removes need for the prep_samples script)

I'd like to make a release, perhaps v0.2? So that folks can download that release for their usage of the scripts, rather than `git clone`ing the most recent developments